### PR TITLE
Fix crc32 function prototype mismatch

### DIFF
--- a/crc32.h
+++ b/crc32.h
@@ -11,8 +11,9 @@ extern "C" {
 #endif
 
 #include <stdint.h>
+#include <string.h>
 
-uint32_t crc32_calc(const char *, int);
+uint32_t crc32_calc(const char *, size_t);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This pull request fixes the fix crc32 function prototype mismatch.

If you enable LTO (Link Time Optimization) for the project, GCC will complain that `crc32_calc` function violates the ODR (One Definition Rule) and may mis-optimize the code (due to `int` and `size_t` having different widths).