### PR TITLE
Fixes for type mismatches and compiler warnings

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 The MIT License (MIT)
 
-Copyright (c) 2013, Joyent, Inc.
+Copyright (c) 2013 Joyent, Inc.
+Copyright (c) 2024 MNX Cloud, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/base64.c
+++ b/base64.c
@@ -1,15 +1,18 @@
 /*
- * Copyright (c) 2013, Joyent, Inc.
  * See LICENSE file for copyright and license details.
+ *
+ * Copyright (c) 2013 Joyent, Inc.
+ * Copyright (c) 2024 MNX Cloud, Inc.
  *
  * Portions based on Public Domain work obtained from:
  *  https://shell.franken.de/svn/sky/xmlstorage/trunk/c++/xmlrpc/base64.cpp
  */
 
-#include "stdlib.h"
-#include "stdio.h"
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
 #include "dynstr.h"
-#include "stdint.h"
 
 static const char base64[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
     "abcdefghijklmnopqrstuvwxyz0123456789+/";

--- a/common.c
+++ b/common.c
@@ -1,10 +1,14 @@
 /*
- * Copyright (c) 2013, Joyent, Inc.
  * See LICENSE file for copyright and license details.
+ *
+ * Copyright (c) 2013 Joyent, Inc.
+ * Copyright (c) 2024 MNX Cloud, Inc.
  */
 
-#include <stdlib.h>
 #include <stdio.h>
+#include <stdlib.h>
+
+#include "common.h"
 
 int
 print_and_abort(const char *message, const char *file, int line)

--- a/crc32.c
+++ b/crc32.c
@@ -1,12 +1,15 @@
 /*
- * Copyright (c) 2013, Joyent, Inc.
  * See LICENSE file for copyright and license details.
+ *
+ * Copyright (c) 2013 Joyent, Inc.
+ * Copyright (c) 2024 MNX Cloud, Inc.
  */
 
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <stdint.h>
 
+#include "crc32.h"
 #include "dynstr.h"
 
 /*

--- a/crc32.h
+++ b/crc32.h
@@ -12,7 +12,7 @@ extern "C" {
 
 #include <stdint.h>
 
-uint32_t crc32_calc(const char *, int);
+uint32_t crc32_calc(const char *, size_t);
 
 #ifdef __cplusplus
 }

--- a/dynstr.c
+++ b/dynstr.c
@@ -1,10 +1,12 @@
 /*
- * Copyright (c) 2013, Joyent, Inc.
  * See LICENSE file for copyright and license details.
+ *
+ * Copyright (c) 2013 Joyent, Inc.
+ * Copyright (c) 2024 MNX Cloud, Inc.
  */
 
-#include <stdlib.h>
 #include <err.h>
+#include <stdlib.h>
 #include <string.h>
 
 #include "dynstr.h"

--- a/dynstr.c
+++ b/dynstr.c
@@ -42,7 +42,7 @@ dynstr_cstr(string_t *str)
 void
 dynstr_appendc(string_t *str, char newc)
 {
-	int chunksz = STRING_CHUNK_SIZE;
+	size_t chunksz = STRING_CHUNK_SIZE;
 
 	if (str->str_strlen + 1 >= str->str_datalen) {
 		str->str_datalen += chunksz;
@@ -57,8 +57,8 @@ dynstr_appendc(string_t *str, char newc)
 void
 dynstr_append(string_t *str, const char *news)
 {
-	int len = strlen(news);
-	int chunksz = STRING_CHUNK_SIZE;
+	size_t len = strlen(news);
+	size_t chunksz = STRING_CHUNK_SIZE;
 
 	while (chunksz < len)
 		chunksz *= 2;

--- a/mdata_delete.c
+++ b/mdata_delete.c
@@ -1,18 +1,20 @@
 /*
- * Copyright (c) 2013, Joyent, Inc.
  * See LICENSE file for copyright and license details.
+ *
+ * Copyright (c) 2013 Joyent, Inc.
+ * Copyright (c) 2024 MNX Cloud, Inc.
  */
 
-#include <stdlib.h>
-#include <stdio.h>
 #include <sys/types.h>
 #include <sys/stat.h>
-#include <fcntl.h>
-#include <unistd.h>
 #include <err.h>
 #include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <strings.h>
+#include <unistd.h>
 
 #include "common.h"
 #include "dynstr.h"

--- a/mdata_delete.c
+++ b/mdata_delete.c
@@ -57,7 +57,7 @@ main(int argc, char **argv)
 	mdata_proto_t *mdp;
 	mdata_response_t mdr;
 	string_t *data;
-	char *errmsg = NULL;
+	const char *errmsg = NULL;
 
 	if (argc < 2) {
 		errx(MDEC_USAGE_ERROR, "Usage: %s <keyname>", argv[0]);

--- a/mdata_get.c
+++ b/mdata_get.c
@@ -63,7 +63,7 @@ main(int argc, char **argv)
 	mdata_proto_t *mdp;
 	mdata_response_t mdr;
 	string_t *data;
-	char *errmsg = NULL;
+	const char *errmsg = NULL;
 
 	if (argc < 2) {
 		errx(MDEC_USAGE_ERROR, "Usage: %s <keyname>", argv[0]);

--- a/mdata_get.c
+++ b/mdata_get.c
@@ -1,18 +1,20 @@
 /*
- * Copyright (c) 2013, Joyent, Inc.
  * See LICENSE file for copyright and license details.
+ *
+ * Copyright (c) 2013 Joyent, Inc.
+ * Copyright (c) 2024 MNX Cloud, Inc.
  */
 
-#include <stdlib.h>
-#include <stdio.h>
 #include <sys/types.h>
 #include <sys/stat.h>
-#include <fcntl.h>
-#include <unistd.h>
 #include <err.h>
 #include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <strings.h>
+#include <unistd.h>
 
 #include "common.h"
 #include "dynstr.h"

--- a/mdata_list.c
+++ b/mdata_list.c
@@ -1,18 +1,20 @@
 /*
- * Copyright (c) 2013, Joyent, Inc.
  * See LICENSE file for copyright and license details.
+ *
+ * Copyright (c) 2013 Joyent, Inc.
+ * Copyright (c) 2024 MNX Cloud, Inc.
  */
 
-#include <stdlib.h>
-#include <stdio.h>
 #include <sys/types.h>
 #include <sys/stat.h>
-#include <fcntl.h>
-#include <unistd.h>
 #include <err.h>
 #include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <strings.h>
+#include <unistd.h>
 
 #include "common.h"
 #include "dynstr.h"

--- a/mdata_list.c
+++ b/mdata_list.c
@@ -60,7 +60,7 @@ main(int argc __UNUSED, char **argv __UNUSED)
 	mdata_proto_t *mdp;
 	mdata_response_t mdr;
 	string_t *data;
-	char *errmsg = NULL;
+	const char *errmsg = NULL;
 
 	if (proto_init(&mdp, &errmsg) != 0) {
 		fprintf(stderr, "ERROR: could not initialise protocol: %s\n",

--- a/mdata_put.c
+++ b/mdata_put.c
@@ -1,24 +1,26 @@
 /*
- * Copyright (c) 2013, Joyent, Inc.
  * See LICENSE file for copyright and license details.
+ *
+ * Copyright (c) 2013 Joyent, Inc.
+ * Copyright (c) 2024 MNX Cloud, Inc.
  */
 
-#include <stdlib.h>
-#include <stdio.h>
 #include <sys/types.h>
 #include <sys/stat.h>
-#include <fcntl.h>
-#include <unistd.h>
 #include <err.h>
 #include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <strings.h>
+#include <unistd.h>
 
+#include "base64.h"
 #include "common.h"
 #include "dynstr.h"
 #include "plat.h"
 #include "proto.h"
-#include "base64.h"
 
 typedef enum mdata_exit_codes {
 	MDEC_SUCCESS = 0,

--- a/mdata_put.c
+++ b/mdata_put.c
@@ -58,7 +58,7 @@ main(int argc, char **argv)
 	mdata_proto_t *mdp;
 	mdata_response_t mdr;
 	string_t *data;
-	char *errmsg = NULL;
+	const char *errmsg = NULL;
 	string_t *req = dynstr_new();
 
 	if (argc < 2) {

--- a/plat.h
+++ b/plat.h
@@ -17,7 +17,7 @@ typedef struct mdata_plat mdata_plat_t;
 int plat_is_interactive(void);
 
 /*int open_metadata_stream(FILE **fp, char **err);*/
-int plat_init(mdata_plat_t **, char **er, int *);
+int plat_init(mdata_plat_t **, const char **, int *);
 int plat_recv(mdata_plat_t *, string_t *, int);
 int plat_send(mdata_plat_t *, string_t *);
 void plat_fini(mdata_plat_t *);

--- a/plat.h
+++ b/plat.h
@@ -18,7 +18,7 @@ int plat_is_interactive(void);
 
 /*int open_metadata_stream(FILE **fp, char **err);*/
 int plat_init(mdata_plat_t **, const char **, int *);
-int plat_recv(mdata_plat_t *, string_t *, int);
+int plat_recv(mdata_plat_t *, string_t *, time_t);
 int plat_send(mdata_plat_t *, string_t *);
 void plat_fini(mdata_plat_t *);
 

--- a/plat/bsd.c
+++ b/plat/bsd.c
@@ -145,7 +145,7 @@ plat_is_interactive(void)
 }
 
 int
-plat_init(mdata_plat_t **mplout, char **errmsg, int *permfail)
+plat_init(mdata_plat_t **mplout, const char **errmsg, int *permfail)
 {
 	mdata_plat_t *mpl = NULL;
 

--- a/plat/bsd.c
+++ b/plat/bsd.c
@@ -44,9 +44,9 @@ typedef struct mdata_plat {
 int
 plat_send(mdata_plat_t *mpl, string_t *data)
 {
-	int len = dynstr_len(data);
+	size_t len = dynstr_len(data);
 
-	if (write(mpl->mpl_conn, dynstr_cstr(data), len) != len)
+	if (write(mpl->mpl_conn, dynstr_cstr(data), len) != (ssize_t)len)
 		return (-1);
 
 	return (0);

--- a/plat/bsd.c
+++ b/plat/bsd.c
@@ -53,9 +53,9 @@ plat_send(mdata_plat_t *mpl, string_t *data)
 }
 
 int
-plat_recv(mdata_plat_t *mpl, string_t *data, int timeout_ms)
+plat_recv(mdata_plat_t *mpl, string_t *data, time_t timeout_ms)
 {
-	struct timespec timeout = { (time_t)(timeout_ms/1000), 0 };
+	struct timespec timeout = { (timeout_ms/1000), 0 };
 
 	for (;;) {
 		struct kevent mpl_ch;

--- a/plat/bsd.c
+++ b/plat/bsd.c
@@ -1,28 +1,28 @@
 /*
- * Copyright (c) 2013, Joyent, Inc.
  * See LICENSE file for copyright and license details.
+ *
+ * Copyright (c) 2013 Joyent, Inc.
+ * Copyright (c) 2024 MNX Cloud, Inc.
  */
 
-#include <stdlib.h>
-#include <stdio.h>
-#include <err.h>
-#include <string.h>
-#include <strings.h>
 #include <sys/types.h>
+#include <sys/event.h>
+#include <sys/socket.h>
 #include <sys/stat.h>
-#include <fcntl.h>
-#include <unistd.h>
+#include <sys/un.h>
 #include <err.h>
 #include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <strings.h>
 #include <termios.h>
-#include <sys/socket.h>
-#include <sys/un.h>
-
-#include <sys/event.h>
+#include <unistd.h>
 
 #include "common.h"
-#include "plat.h"
 #include "dynstr.h"
+#include "plat.h"
 #include "plat/unix_common.h"
 
 #if defined(__NetBSD__)

--- a/plat/linux.c
+++ b/plat/linux.c
@@ -132,7 +132,7 @@ plat_is_interactive(void)
 }
 
 int
-plat_init(mdata_plat_t **mplout, char **errmsg, int *permfail)
+plat_init(mdata_plat_t **mplout, const char **errmsg, int *permfail)
 {
 	mdata_plat_t *mpl = NULL;
 	struct epoll_event event;

--- a/plat/linux.c
+++ b/plat/linux.c
@@ -36,9 +36,9 @@ struct mdata_plat {
 int
 plat_send(mdata_plat_t *mpl, string_t *data)
 {
-	int len = dynstr_len(data);
+	size_t len = dynstr_len(data);
 
-	if (write(mpl->mpl_conn, dynstr_cstr(data), len) != len)
+	if (write(mpl->mpl_conn, dynstr_cstr(data), len) != (ssize_t)len)
 		return (-1);
 
 	return (0);

--- a/plat/linux.c
+++ b/plat/linux.c
@@ -1,28 +1,28 @@
 /*
- * Copyright (c) 2013, Joyent, Inc.
  * See LICENSE file for copyright and license details.
+ *
+ * Copyright (c) 2013 Joyent, Inc.
+ * Copyright (c) 2024 MNX Cloud, Inc.
  */
 
-#include <stdlib.h>
-#include <stdio.h>
-#include <err.h>
-#include <string.h>
-#include <strings.h>
 #include <sys/types.h>
+#include <sys/epoll.h>
+#include <sys/socket.h>
 #include <sys/stat.h>
-#include <fcntl.h>
-#include <unistd.h>
+#include <sys/un.h>
 #include <err.h>
 #include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <strings.h>
 #include <termios.h>
-#include <sys/socket.h>
-#include <sys/un.h>
-
-#include <sys/epoll.h>
+#include <unistd.h>
 
 #include "common.h"
-#include "plat.h"
 #include "dynstr.h"
+#include "plat.h"
 #include "plat/unix_common.h"
 
 #define	SERIAL_DEVICE	"/dev/ttyS1"

--- a/plat/linux.c
+++ b/plat/linux.c
@@ -45,7 +45,7 @@ plat_send(mdata_plat_t *mpl, string_t *data)
 }
 
 int
-plat_recv(mdata_plat_t *mpl, string_t *data, int timeout_ms)
+plat_recv(mdata_plat_t *mpl, string_t *data, time_t timeout_ms)
 {
 	for (;;) {
 		struct epoll_event event;

--- a/plat/sunos.c
+++ b/plat/sunos.c
@@ -3,23 +3,22 @@
  * See LICENSE file for copyright and license details.
  */
 
-#include <stdlib.h>
-#include <err.h>
-#include <smbios.h>
-#include <string.h>
-#include <strings.h>
 #include <sys/types.h>
+#include <sys/filio.h>
+#include <sys/socket.h>
 #include <sys/stat.h>
-#include <fcntl.h>
-#include <unistd.h>
+#include <sys/un.h>
 #include <err.h>
 #include <errno.h>
-#include <termios.h>
-#include <zone.h>
-#include <sys/socket.h>
-#include <sys/un.h>
-#include <sys/filio.h>
+#include <fcntl.h>
 #include <port.h>
+#include <smbios.h>
+#include <stdlib.h>
+#include <string.h>
+#include <strings.h>
+#include <termios.h>
+#include <unistd.h>
+#include <zone.h>
 
 #include "common.h"
 #include "dynstr.h"

--- a/plat/sunos.c
+++ b/plat/sunos.c
@@ -107,7 +107,7 @@ find_md_ngz(const char **out, int *permfail)
 }
 
 static int
-open_md_ngz(int *outfd, char **errmsg, int *permfail)
+open_md_ngz(int *outfd, const char **errmsg, int *permfail)
 {
 	/*
 	 * We're in a non-global zone, so try and connect to the
@@ -161,7 +161,7 @@ open_md_ngz(int *outfd, char **errmsg, int *permfail)
 }
 
 static int
-open_md_gz(int *outfd, char **errmsg, int *permfail)
+open_md_gz(int *outfd, const char **errmsg, int *permfail)
 {
 	/*
 	 * We're in a global zone in a SmartOS KVM/QEMU instance, so
@@ -280,7 +280,7 @@ plat_is_interactive(void)
 }
 
 int
-plat_init(mdata_plat_t **mplout, char **errmsg, int *permfail)
+plat_init(mdata_plat_t **mplout, const char **errmsg, int *permfail)
 {
 	char *product;
 	boolean_t smartdc_hvm_guest = B_FALSE;

--- a/plat/sunos.c
+++ b/plat/sunos.c
@@ -174,9 +174,9 @@ open_md_gz(int *outfd, char **errmsg, int *permfail)
 int
 plat_send(mdata_plat_t *mpl, string_t *data)
 {
-	int len = dynstr_len(data);
+	size_t len = dynstr_len(data);
 
-	if (write(mpl->mpl_conn, dynstr_cstr(data), len) != len)
+	if (write(mpl->mpl_conn, dynstr_cstr(data), len) != (ssize_t)len)
 		return (-1);
 
 	return (0);

--- a/plat/sunos.c
+++ b/plat/sunos.c
@@ -183,7 +183,7 @@ plat_send(mdata_plat_t *mpl, string_t *data)
 }
 
 int
-plat_recv(mdata_plat_t *mpl, string_t *data, int timeout_ms)
+plat_recv(mdata_plat_t *mpl, string_t *data, time_t timeout_ms)
 {
 	port_event_t pev;
 	timespec_t tv;

--- a/plat/sunos.c
+++ b/plat/sunos.c
@@ -190,7 +190,7 @@ plat_recv(mdata_plat_t *mpl, string_t *data, time_t timeout_ms)
 
 	for (;;) {
 		if (port_associate(mpl->mpl_port, PORT_SOURCE_FD,
-		    (uintptr_r)mpl->mpl_conn, POLLIN | POLLERR | POLLHUP,
+		    (uintptr_t)mpl->mpl_conn, POLLIN | POLLERR | POLLHUP,
 		    NULL) != 0) {
 			fprintf(stderr, "port_associate error: %s\n",
 			    strerror(errno));

--- a/plat/sunos.c
+++ b/plat/sunos.c
@@ -189,8 +189,9 @@ plat_recv(mdata_plat_t *mpl, string_t *data, int timeout_ms)
 	timespec_t tv;
 
 	for (;;) {
-		if (port_associate(mpl->mpl_port, PORT_SOURCE_FD, mpl->mpl_conn,
-		    POLLIN | POLLERR | POLLHUP , NULL) != 0) {
+		if (port_associate(mpl->mpl_port, PORT_SOURCE_FD,
+		    (uintptr_r)mpl->mpl_conn, POLLIN | POLLERR | POLLHUP,
+		    NULL) != 0) {
 			fprintf(stderr, "port_associate error: %s\n",
 			    strerror(errno));
 			return (-1);

--- a/plat/sunos.c
+++ b/plat/sunos.c
@@ -27,7 +27,7 @@
 
 #define	IN_GLOBAL_DEVICE	"/dev/term/b"
 
-static char *zone_md_socket_paths[] = {
+static const char *zone_md_socket_paths[] = {
 	"/.zonecontrol/metadata.sock",		/* SDC7 */
 	"/native/.zonecontrol/metadata.sock",	/* SDC7+LX */
 	"/var/run/smartdc/metadata.sock",	/* SDC6 */

--- a/plat/unix_common.c
+++ b/plat/unix_common.c
@@ -27,7 +27,7 @@ unix_is_interactive(void)
 }
 
 static int
-unix_raw_mode(int fd, char **errmsg)
+unix_raw_mode(int fd, const char **errmsg)
 {
 	struct termios tios;
 
@@ -59,7 +59,7 @@ unix_raw_mode(int fd, char **errmsg)
 }
 
 int
-unix_open_serial(char *devpath, int *outfd, char **errmsg, int *permfail)
+unix_open_serial(const char *devpath, int *outfd, const char **errmsg, int *permfail)
 {
 	int fd;
 	char scrap[100];

--- a/plat/unix_common.c
+++ b/plat/unix_common.c
@@ -38,11 +38,11 @@ unix_raw_mode(int fd, const char **errmsg)
 		return (-1);
 	}
 
-	tios.c_iflag &= ~(BRKINT | ICRNL | INPCK | ISTRIP | IXON);
-	tios.c_oflag &= ~(OPOST);
-	tios.c_cflag |= (CS8);
-	tios.c_cflag &= ~(HUPCL);
-	tios.c_lflag &= ~(ECHO | ICANON | IEXTEN | ISIG);
+	tios.c_iflag &= (tcflag_t)~(BRKINT | ICRNL | INPCK | ISTRIP | IXON);
+	tios.c_oflag &= (tcflag_t)~(OPOST);
+	tios.c_cflag |= (tcflag_t)(CS8);
+	tios.c_cflag &= (tcflag_t)~(HUPCL);
+	tios.c_lflag &= (tcflag_t)~(ECHO | ICANON | IEXTEN | ISIG);
 
 	/*
 	 * As described in "Case C: MIN = 0, TIME > 0" of termio(7I), this

--- a/plat/unix_common.c
+++ b/plat/unix_common.c
@@ -1,24 +1,26 @@
 /*
- * Copyright (c) 2013, Joyent, Inc.
  * See LICENSE file for copyright and license details.
+ *
+ * Copyright (c) 2013 Joyent, Inc.
+ * Copyright (c) 2024 MNX Cloud, Inc.
  */
 
-#include <stdlib.h>
-#include <stdio.h>
-#include <err.h>
-#include <string.h>
-#include <strings.h>
 #include <sys/types.h>
 #include <sys/stat.h>
-#include <fcntl.h>
-#include <unistd.h>
 #include <err.h>
 #include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <strings.h>
 #include <termios.h>
+#include <unistd.h>
 
 #include "common.h"
-#include "plat.h"
 #include "dynstr.h"
+#include "plat.h"
+#include "unix_common.h"
 
 int
 unix_is_interactive(void)

--- a/plat/unix_common.h
+++ b/plat/unix_common.h
@@ -14,7 +14,7 @@ extern "C" {
 #include "dynstr.h"
 
 /*int unix_raw_mode(int fd, char **errmsg);*/
-int unix_open_serial(char *devpath, int *outfd, char **errmsg, int *permfail);
+int unix_open_serial(const char *, int *, const char **, int *);
 int unix_send_reset(mdata_plat_t *mpl);
 int unix_is_interactive(void);
 

--- a/proto.c
+++ b/proto.c
@@ -60,8 +60,8 @@ struct mdata_proto {
 	mdata_proto_state_t mdp_state;
 	mdata_proto_version_t mdp_version;
 	boolean_t mdp_in_reset;
-	char *mdp_errmsg;
-	char *mdp_parse_errmsg;
+	const char *mdp_errmsg;
+	const char *mdp_parse_errmsg;
 };
 
 static int proto_send(mdata_proto_t *mdp);
@@ -153,6 +153,7 @@ proto_parse_v2(mdata_proto_t *mdp, string_t *input, string_t *request_id,
 	const char *endp = dynstr_cstr(input);
 	unsigned long clen;
 	uint32_t crc32;
+	char *endp2;
 
 	mdp->mdp_parse_errmsg = NULL;
 
@@ -165,10 +166,11 @@ proto_parse_v2(mdata_proto_t *mdp, string_t *input, string_t *request_id,
 	/*
 	 * Read Content Length:
 	 */
-	if ((clen = strtoul(endp, (char **) &endp, 10)) == 0) {
+	if ((clen = strtoul(endp, &endp2, 10)) == 0) {
 		mdp->mdp_parse_errmsg = "invalid content length";
 		return (-1);
 	}
+	endp = endp2;
 
 	/*
 	 * Skip whitespace:
@@ -179,10 +181,11 @@ proto_parse_v2(mdata_proto_t *mdp, string_t *input, string_t *request_id,
 	/*
 	 * Read CRC32 checksum:
 	 */
-	if ((crc32 = strtoul(endp, (char **) &endp, 16)) == 0) {
+	if ((crc32 = strtoul(endp, &endp2, 16)) == 0) {
 		mdp->mdp_parse_errmsg = "invalid crc32 in frame";
 		return (-1);
 	}
+	endp = endp2;
 
 	/*
 	 * Skip whitespace:
@@ -571,7 +574,7 @@ proto_version(mdata_proto_t *mdp)
 }
 
 int
-proto_init(mdata_proto_t **out, char **errmsg)
+proto_init(mdata_proto_t **out, const char **errmsg)
 {
 	mdata_proto_t *mdp;
 

--- a/proto.c
+++ b/proto.c
@@ -153,9 +153,8 @@ proto_parse_v2(mdata_proto_t *mdp, string_t *input, string_t *request_id,
     string_t *command, string_t *response_data)
 {
 	const char *endp = dynstr_cstr(input);
-	unsigned long clen;
-	uint32_t crc32;
 	char *endp2;
+	unsigned long clen, crc32;
 
 	mdp->mdp_parse_errmsg = NULL;
 
@@ -572,7 +571,7 @@ bail:
 int
 proto_version(mdata_proto_t *mdp)
 {
-	return (mdp->mdp_version);
+	return ((int)mdp->mdp_version);
 }
 
 int

--- a/proto.c
+++ b/proto.c
@@ -1,26 +1,28 @@
 /*
- * Copyright (c) 2013, Joyent, Inc.
  * See LICENSE file for copyright and license details.
+ *
+ * Copyright (c) 2013 Joyent, Inc.
+ * Copyright (c) 2024 MNX Cloud, Inc.
  */
 
-#include <stdlib.h>
-#include <stdio.h>
 #include <sys/types.h>
 #include <sys/stat.h>
-#include <fcntl.h>
-#include <unistd.h>
 #include <err.h>
 #include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <strings.h>
+#include <unistd.h>
 
+#include "base64.h"
 #include "common.h"
+#include "crc32.h"
 #include "dynstr.h"
 #include "plat.h"
 #include "proto.h"
 #include "reqid.h"
-#include "crc32.h"
-#include "base64.h"
 
 /*
  * Receive timeout used prior to V2 negotiation:

--- a/proto.h
+++ b/proto.h
@@ -21,7 +21,7 @@ typedef enum mdata_response {
 
 typedef struct mdata_proto mdata_proto_t;
 
-int proto_init(mdata_proto_t **, char **);
+int proto_init(mdata_proto_t **, const char **);
 int proto_version(mdata_proto_t *);
 int proto_execute(mdata_proto_t *, const char *, const char *, mdata_response_t *,
     string_t **);

--- a/reqid.c
+++ b/reqid.c
@@ -1,17 +1,19 @@
 /*
- * Copyright (c) 2013, Joyent, Inc.
  * See LICENSE file for copyright and license details.
+ *
+ * Copyright (c) 2013 Joyent, Inc.
+ * Copyright (c) 2024 MNX Cloud, Inc.
  */
 
-#include <stdlib.h>
-#include <stdio.h>
-#include <stdint.h>
 #include <sys/types.h>
 #include <errno.h>
-#include <unistd.h>
 #include <fcntl.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
 #include <sys/uio.h>
 #include <time.h>
+#include <unistd.h>
 
 #include "common.h"
 #include "reqid.h"

--- a/reqid.c
+++ b/reqid.c
@@ -25,7 +25,7 @@ reqid(char *buf)
 {
 	int i;
 	static int seed = -1;
-	uint32_t tmp = 0;
+	int32_t tmp = 0;
 
 	VERIFY(buf != NULL);
 
@@ -43,7 +43,7 @@ reqid(char *buf)
 	 */
 	if (seed == -1) {
 		seed = (int) time(NULL);
-		srand(seed);
+		srand((unsigned int)seed);
 
 	}
 	for (i = 0; i < 4; i++) {


### PR DESCRIPTION
This bundles up fixes from #9 and #23, as well as a bunch of my own, into one change that fixes various compiler warnings and type issues.

The warning flags enabled were from NetBSD's highest `WARNS` setting, which are as follows:

* GCC: `-Wall -Wstrict-prototypes -Wmissing-prototypes -Wpointer-arith -Wno-sign-compare  -Wsystem-headers   -Wno-traditional   -Wa,--fatal-warnings  -Wreturn-type -Wswitch -Wshadow -Wcast-qual -Wwrite-strings -Wextra -Wno-unused-parameter -Wno-sign-compare -Wold-style-definition -Wconversion -Wsign-compare -Wformat=2  -Wno-format-zero-length  -Werror`
* clang: `-Wno-sign-compare -Wno-pointer-sign  -Wall -Wstrict-prototypes -Wmissing-prototypes -Wpointer-arith -Wno-sign-compare    -Wreturn-type -Wswitch -Wshadow -Wcast-qual -Wwrite-strings -Wextra -Wno-unused-parameter -Wno-sign-compare -Wold-style-definition -Wconversion -Wsign-compare -Wformat=2  -Werror`

Testing was performed on macOS (build-only for clang checks), NetBSD, Linux, and SmartOS.